### PR TITLE
add user to video group

### DIFF
--- a/src/ros/.devcontainer/Dockerfile
+++ b/src/ros/.devcontainer/Dockerfile
@@ -14,6 +14,9 @@ RUN groupadd --gid $USER_GID $USERNAME \
 # Switch from root to user
 USER $USERNAME
 
+# Add user to video group to allow access to webcam
+RUN sudo usermod --append --groups video $USERNAME
+
 # Update all packages
 RUN sudo apt update && sudo apt upgrade -y
 

--- a/src/ros/devcontainer-template.json
+++ b/src/ros/devcontainer-template.json
@@ -1,6 +1,6 @@
 {
   "id": "ros",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "name": "ROS",
   "description": "A ROS Template",
   "options": {


### PR DESCRIPTION
Resolves: #13 

This allows the user to access /dev/video0, /dev/video1, etc.

Followed instructions from https://medium.com/@zwinny/docker-using-webcam-9fafb26cf1e6