### PR TITLE
Fixed issue with naming scheme with network binding run args.

### DIFF
--- a/src/ros/.devcontainer/devcontainer.json
+++ b/src/ros/.devcontainer/devcontainer.json
@@ -3,7 +3,7 @@
   "dockerFile": "Dockerfile",
   "runArgs": [
     "--privileged",
-    "--network=host"
+    "--net=host"
   ],
   "workspaceMount": "source=${localWorkspaceFolder},target=/${localWorkspaceFolderBasename},type=bind",
   "workspaceFolder": "/${localWorkspaceFolderBasename}",


### PR DESCRIPTION
ROS2 will refuse to communicate between terminals and to external devices as the parameter is named incorrectly. This change renames to the proper runtime argument and allows ROS2 to communicate properly by binding to the host's network.